### PR TITLE
chore: disable ssdp with config

### DIFF
--- a/custom_components/solar_manager/__init__.py
+++ b/custom_components/solar_manager/__init__.py
@@ -36,11 +36,14 @@ type SolarManagerConfigEntry = ConfigEntry
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Solar Manager integration."""
     hass.data.setdefault(DOMAIN, {})
-    # Initialize SSDP broadcaster for the entire integration
-    if "broadcaster" not in hass.data[DOMAIN]:
-        broadcaster = SSDPBroadcaster(hass, interval=5.0)
-        hass.data[DOMAIN]["broadcaster"] = broadcaster
-        await broadcaster.start()
+
+    solar_cfg = config.get(DOMAIN, {})
+    if solar_cfg.get("ssdpbroadcaster", True): 
+        # Initialize SSDP broadcaster for the entire integration
+        if "broadcaster" not in hass.data[DOMAIN]:
+            broadcaster = SSDPBroadcaster(hass, interval=5.0)
+            hass.data[DOMAIN]["broadcaster"] = broadcaster
+            await broadcaster.start()
     return True
 
 


### PR DESCRIPTION
Sometimes there are multi solar-manager installed in one envionment, but it will reboot module devices always, as the ip is changing 5s seconds due to two agent. This change add the possibility for disabling ssdp.

## Change Description
Disable ssdp with config

## Related Issues
No so far, but if there are two solar manager installed in different agent device, module will restart.

## Influence device

- [x] MakeSkyBlue
- [x] MakeSkyBlue Mppt

## Testing
Describe how you tested these changes:
P1: Verify that module device won't reboot always
* Install two solar manager in different HA agent
* Config for same device in these two different agent
* add  below config in yaml
   '''
   solar_manager: 
       ssdpbroadcaster: false
    '''
Verify that module don't reboot always.                

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed
- [ ] Documentation updated (if needed)
- [ ] No new warnings or errors
- [ ] Local tests passed
