### PR TITLE
feat: add Switches device type with dynamic switch count

### DIFF
--- a/custom_components/solar_manager/device_protocol/device_config.py
+++ b/custom_components/solar_manager/device_protocol/device_config.py
@@ -12,6 +12,7 @@ from custom_components.solar_manager.plugins.MakeSkyBlueIoTrix import MakeSkyBlu
 from custom_components.solar_manager.plugins.MakeSkyBlueMppt import MakeSkyBlueMppt
 from custom_components.solar_manager.plugins.Megarevo import Megarevo
 from custom_components.solar_manager.plugins.PZemV04 import PZemV04
+from custom_components.solar_manager.plugins.Switches import SwitchesDevice
 
 # Unified device configuration
 DEVICE_CONFIG = {
@@ -42,6 +43,10 @@ DEVICE_CONFIG = {
     "PZEMV04": {
         "protocol": "pzem_v04",
         "device_class": PZemV04,
+    },
+    "Switches": {
+        "protocol": "switches",
+        "device_class": SwitchesDevice,
     },
 }
 

--- a/custom_components/solar_manager/device_protocol/switches.json
+++ b/custom_components/solar_manager/device_protocol/switches.json
@@ -1,0 +1,4 @@
+{
+    "control_type": "JSON",
+    "min_switch_count": 2
+}

--- a/custom_components/solar_manager/plugins/Switches.py
+++ b/custom_components/solar_manager/plugins/Switches.py
@@ -1,0 +1,419 @@
+"""Switches device class for Solar Manager integration.
+
+Solar Manager or solar_manager © 2025 by @maybetaken is
+licensed under Creative Commons
+Attribution-NonCommercial-NoDerivatives 4.0 International.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable, Optional
+
+from custom_components.solar_manager.const import DOMAIN
+from custom_components.solar_manager.protocol_helper.json_protocol_helper import (
+    JsonProtocolHelper,
+)
+
+from homeassistant.core import HomeAssistant
+
+from .base_device import BaseDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SwitchesDevice(BaseDevice):
+    """Switches device class for Solar Manager integration.
+
+    A logical multi-switch controller that exposes two or more binary
+    on/off switch entities. Serial numbers ending with ``-K`` identify
+    attached (sub-module) variants that share another device's network
+    connection and therefore SHALL NOT expose network diagnostic
+    entities or maintenance buttons.
+    """
+
+    MIN_SWITCH_COUNT = 2
+    ATTACHED_SUFFIX = "-K"
+    MAX_PAYLOAD_PREVIEW = 64
+
+    def __init__(
+        self, hass: HomeAssistant, protocol_file: str, sn: str, model: str
+    ) -> None:
+        """Initialize the Switches device.
+
+        Classifies the device as attached or standalone based on the
+        serial number suffix BEFORE delegating to ``BaseDevice.__init__``
+        so that ``enable_diagnostics`` can be flipped for attached
+        sub-modules.
+        """
+        is_attached = sn.endswith(self.ATTACHED_SUFFIX)
+        super().__init__(
+            hass,
+            protocol_file,
+            sn,
+            model,
+            enable_diagnostics=not is_attached,
+        )
+        self._is_attached = is_attached
+        self._switch_count = self.MIN_SWITCH_COUNT
+        self._add_entities_cb: Optional[Callable[[list[Any]], Any]] = None
+        self._pending_target_count: Optional[int] = None
+        self.parser = JsonProtocolHelper(hass, protocol_file)
+        self.setup_protocol()
+
+    @staticmethod
+    def switch_name(index_one_based: int) -> str:
+        """Return the canonical translation-key name for a switch index.
+
+        Indices are one-based and zero-padded to at least two digits, so
+        the first switch is ``switch_01``, the tenth is ``switch_10``,
+        and the sixteenth is ``switch_16``.
+        """
+        return f"switch_{index_one_based:02d}"
+
+    def setup_protocol(self) -> None:
+        """Set up device-specific protocol parameters.
+
+        Switches use JSON-over-MQTT commands rather than Modbus register
+        polling. The protocol helper still routes user-facing writes
+        through ``handle_cmd`` so the command payload is published on
+        ``{serial}/control/cmd``.
+        """
+        self.parser.register_callback(self.handle_cmd)
+
+    async def send_config(self) -> None:
+        """Publish an empty JSON config for parity with other plugins.
+
+        Switches does not carry Modbus segments, so the config payload is
+        an empty JSON object. Emitting the topic keeps the firmware side
+        compatible with the existing "HA sent config" handshake.
+        """
+        try:
+            await self.mqtt_manager.publish(
+                self._build_topic("config"), json.dumps({})
+            )
+        except Exception as err:  # noqa: BLE001 - mirror other plugins' broad guard
+            _LOGGER.error("Config send failed for %s: %s", self.sn, err)
+
+    def set_add_entities_callback(
+        self, cb: Callable[[list[Any]], Any]
+    ) -> None:
+        """Store the platform's ``async_add_entities`` callback.
+
+        Captured by ``switch.py`` so that later online-payload-driven
+        growth in ``handle_online`` can add switch entities dynamically.
+        If an online payload arrived before the callback was registered,
+        the deferred target count is applied now.
+        """
+        self._add_entities_cb = cb
+        pending = self._pending_target_count
+        if pending is not None and pending > self._switch_count:
+            self._pending_target_count = None
+            self.hass.async_create_task(self._reconcile_to(pending))
+
+    async def unpack_device_info(self) -> dict[str, list[dict[str, Any]]]:
+        """Unpack device information into platform entity groups.
+
+        Delegates to ``BaseDevice.unpack_device_info`` first so that
+        diagnostic sensors (SSID, RSSI), the LED diagnostic switch, and
+        the Restart/Reconfig maintenance buttons are emitted automatically
+        for standalone devices and skipped for attached (``-K``) devices.
+
+        Two default ``switch_01`` and ``switch_02`` entries are always
+        appended. The switch count may grow later when the device
+        publishes its ``switch_count`` on the ``online`` topic; those
+        additional entities are added dynamically via the stored
+        ``async_add_entities`` callback.
+        """
+        device_info = super().unpack_device_info()
+
+        # Reset to the initial default count; later online payloads may
+        # grow (or shrink) the exposed set.
+        self._switch_count = self.MIN_SWITCH_COUNT
+        for index in range(1, self.MIN_SWITCH_COUNT + 1):
+            name = self.switch_name(index)
+            device_info["switch"].append(
+                {
+                    "name": name,
+                    "device": self,
+                    "register": index,
+                    "icon": "mdi:toggle-switch",
+                }
+            )
+
+        return device_info
+
+    async def handle_online(self, topic: str, payload: bytes) -> None:
+        """Handle ``{serial}/online`` messages and reconcile entities.
+
+        Parses the JSON payload, validates a strict ``switch_count``
+        integer field, and reconciles the exposed switch entity set to
+        match. Invalid or malformed payloads log an error, leave the
+        prior count untouched, and still trigger the base-class
+        ``send_config`` behavior so the device side-effects are
+        preserved.
+        """
+        target = self._parse_switch_count(payload)
+        if target is not None:
+            await self._reconcile_to(target)
+
+        # Preserve BaseDevice.handle_online side-effects (log + send_config).
+        await super().handle_online(topic, payload)
+
+    def _parse_switch_count(self, payload: bytes) -> Optional[int]:
+        """Validate the ``online`` payload and return a clean switch count.
+
+        Returns the integer ``switch_count`` if the payload is a JSON
+        object containing a real integer ``>= MIN_SWITCH_COUNT``. On any
+        failure (invalid JSON, non-dict, missing field, wrong type,
+        ``bool``, ``float``, or value below the minimum) logs an error
+        and returns ``None`` so callers keep the previous count.
+        """
+        try:
+            decoded = json.loads(payload)
+        except (json.JSONDecodeError, TypeError, ValueError) as err:
+            _LOGGER.error(
+                "Invalid JSON on online topic for %s: %s (payload preview=%r)",
+                self.sn,
+                err,
+                self._payload_preview(payload),
+            )
+            return None
+
+        if not isinstance(decoded, dict):
+            _LOGGER.error(
+                "Online payload for %s is not a JSON object: %r",
+                self.sn,
+                decoded,
+            )
+            return None
+
+        if "switch_count" not in decoded:
+            _LOGGER.error(
+                "Online payload for %s missing 'switch_count' field: %r",
+                self.sn,
+                decoded,
+            )
+            return None
+
+        value = decoded["switch_count"]
+        # ``bool`` is a subclass of ``int`` — reject it explicitly.
+        if isinstance(value, bool) or not isinstance(value, int):
+            _LOGGER.error(
+                "Online 'switch_count' for %s is not an int: %r",
+                self.sn,
+                value,
+            )
+            return None
+
+        if value < self.MIN_SWITCH_COUNT:
+            _LOGGER.error(
+                "Online 'switch_count'=%d for %s is below minimum %d",
+                value,
+                self.sn,
+                self.MIN_SWITCH_COUNT,
+            )
+            return None
+
+        return value
+
+    @staticmethod
+    def _payload_preview(payload: bytes) -> str:
+        """Return a safe preview of an MQTT payload for logging."""
+        try:
+            text = payload.decode("utf-8", errors="replace")
+        except AttributeError:
+            text = str(payload)
+        if len(text) > SwitchesDevice.MAX_PAYLOAD_PREVIEW:
+            return text[: SwitchesDevice.MAX_PAYLOAD_PREVIEW] + "…"
+        return text
+
+    async def _reconcile_to(self, target_count: int) -> None:
+        """Reconcile the exposed entity set to ``target_count``.
+
+        Grow path: if more entities are needed, create new
+        ``SolarManagerSwitch`` instances and hand them to the platform's
+        stored ``async_add_entities`` callback. If the callback is not
+        yet registered (startup race), buffer the target so
+        ``set_add_entities_callback`` can complete the growth once it is
+        captured.
+
+        Shrink path: entity objects are NOT removed. Their data-dict
+        entries are cleared so ``SolarManagerSwitch.available`` reports
+        ``False``. Automations relying on those entity ids therefore do
+        not break mid-session.
+        """
+        if target_count == self._switch_count:
+            return
+
+        if target_count > self._switch_count:
+            await self._grow_to(target_count)
+        else:
+            self._shrink_to(target_count)
+
+    async def _grow_to(self, target_count: int) -> None:
+        """Add missing switch entities up to ``target_count``."""
+        # Imported lazily to avoid a circular import between the plugin
+        # and the switch platform.
+        from custom_components.solar_manager.switch import SolarManagerSwitch
+
+        if self._add_entities_cb is None:
+            prior = self._pending_target_count or target_count
+            self._pending_target_count = max(prior, target_count)
+            _LOGGER.debug(
+                "Deferring switch growth for %s: target=%d (callback not yet set)",
+                self.sn,
+                self._pending_target_count,
+            )
+            return
+
+        new_entities: list[SolarManagerSwitch] = []
+        for index in range(self._switch_count + 1, target_count + 1):
+            name = self.switch_name(index)
+            unique_id = f"{name}_{self.model}_{self.sn}"
+            entity = SolarManagerSwitch(
+                name=name,
+                model=self.model,
+                device=self,
+                register=index,
+                unique_id=unique_id,
+                device_id=self.sn,
+                icon="mdi:toggle-switch",
+            )
+            new_entities.append(entity)
+
+        if new_entities:
+            self._add_entities_cb(new_entities)
+
+        self._switch_count = target_count
+
+    def _shrink_to(self, target_count: int) -> None:
+        """Mark excess switch entities unavailable without removing them."""
+        for index in range(target_count + 1, self._switch_count + 1):
+            name = self.switch_name(index)
+            self._data_dict[name] = None
+            entity = self._entities.get(name)
+            if entity is not None:
+                entity.schedule_update_ha_state()
+
+        self._switch_count = target_count
+
+    async def handle_notify(self, topic: str, payload: bytes) -> None:
+        """Handle ``{serial}/notify`` state reports from the device.
+
+        Expected payload: a JSON object mapping switch names to states,
+        e.g. ``{"switch_01": "on", "switch_03": "off"}``. Parsing is
+        delegated to ``self.parser.parse_data`` so the JSON decoding
+        logic lives in the shared ``JsonProtocolHelper``.
+        """
+        decoded = self.parser.parse_data(payload)
+        if not decoded:
+            return
+
+        changed: list[str] = []
+        for key, state in decoded.items():
+            index = self._parse_switch_key(key)
+            if index is None:
+                _LOGGER.warning(
+                    "Skipping unknown notify key for %s: %r", self.sn, key
+                )
+                continue
+
+            if index < 1 or index > self._switch_count:
+                _LOGGER.warning(
+                    "Ignoring notify key %r outside [1, %d] for %s",
+                    key,
+                    self._switch_count,
+                    self.sn,
+                )
+                continue
+
+            if state not in ("on", "off"):
+                _LOGGER.warning(
+                    "Skipping notify entry %r with invalid state for %s: %r",
+                    key,
+                    self.sn,
+                    state,
+                )
+                continue
+
+            name = self.switch_name(index)
+            value = 1 if state == "on" else 0
+            if self._data_dict.get(name) != value:
+                self._data_dict[name] = value
+                changed.append(name)
+
+        for name in changed:
+            entity = self._entities.get(name)
+            if entity is not None:
+                entity.schedule_update_ha_state()
+
+        self._reset_notify_clear_timer()
+
+    @staticmethod
+    def _parse_switch_key(key: Any) -> Optional[int]:
+        """Extract a one-based switch index from a ``switch_NN`` key.
+
+        Returns ``None`` if the key is not a ``switch_`` prefixed string
+        or if the trailing portion is not a positive integer.
+        """
+        if not isinstance(key, str) or not key.startswith("switch_"):
+            return None
+        try:
+            index = int(key[len("switch_") :])
+        except ValueError:
+            return None
+        if index < 1:
+            return None
+        return index
+
+    async def handle_cmd(self, cmd: Any, value: Any) -> None:
+        """Publish a switch command to ``{serial}/control/cmd``.
+
+        Accepts ``cmd`` as the one-based switch index and ``value`` as a
+        truthy/falsy-convertible value. Validates the index is within
+        ``[1, _switch_count]`` and logs a clear error if not, never
+        publishing an invalid command onto the wire. The published
+        payload is a JSON object keyed by the canonical switch name,
+        e.g. ``{"switch_03": "on"}``.
+        """
+        try:
+            index = int(cmd)
+        except (TypeError, ValueError):
+            _LOGGER.error(
+                "Switch command index for %s is not an int: %r", self.sn, cmd
+            )
+            return
+
+        if index < 1 or index > self._switch_count:
+            _LOGGER.error(
+                "Switch command index %d out of range [1, %d] for %s",
+                index,
+                self._switch_count,
+                self.sn,
+            )
+            return
+
+        try:
+            bool_value = bool(int(float(value)))
+        except (TypeError, ValueError):
+            _LOGGER.error(
+                "Switch command value for %s index %d is not a boolean: %r",
+                self.sn,
+                index,
+                value,
+            )
+            return
+
+        name = self.switch_name(index)
+        payload = json.dumps({name: "on" if bool_value else "off"})
+        try:
+            await self.mqtt_manager.publish(self.cmd_topic, payload)
+        except Exception as err:  # noqa: BLE001 - mirror other plugins' broad guard
+            _LOGGER.error(
+                "Failed to publish switch command for %s index %d: %s",
+                self.sn,
+                index,
+                err,
+            )

--- a/custom_components/solar_manager/protocol_helper/json_protocol_helper.py
+++ b/custom_components/solar_manager/protocol_helper/json_protocol_helper.py
@@ -1,70 +1,76 @@
-"""Helper for handling JSON protocol files for Solar Manager.
+"""Generic JSON-over-MQTT protocol helper for Solar Manager.
 
-Solar Manager or solar_manager © 2025 by @maybetaken is
+Solar Manager or solar_manager © 2026 by @maybetaken is
 licensed under Creative Commons
 Attribution-NonCommercial-NoDerivatives 4.0 International.
+
+This helper is intended for any device that exchanges JSON payloads
+directly over MQTT (no Modbus framing, no HTTP transport). It provides
+a generic ``parse_data`` for decoding inbound JSON bytes and a
+callback-based ``write_data`` so plugins can route user-facing writes
+through their own ``handle_cmd`` without going through a Modbus-shaped
+``pack_data`` path.
 """
 
-import struct
+from __future__ import annotations
+
+import json
 from typing import Any
 
 from custom_components.solar_manager.const import _LOGGER
-
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .protocol_helper import ProtocolHelper
 
 
 class JsonProtocolHelper(ProtocolHelper):
-    """Class to handle JSON protocol files and Modbus communication."""
+    """Generic JSON-over-MQTT protocol helper.
 
-    async def read_data(self, register_name: str) -> Any:
-        """Read data from the device for a specific register."""
-        if self.protocol_data is None:
-            self.protocol_data = await self.load_protocol()
+    Unlike ``ModbusProtocolHelper`` this class does not carry any
+    register addressing, CRC, or binary packing concerns. It deals in
+    JSON objects in and out of the MQTT topics that the owning plugin
+    subscribes to.
+    """
 
-        details = self.protocol_data["registers"].get(register_name)
-        if not details:
-            raise ValueError(f"Register {register_name} not found in protocol")
+    def register_callback(self, callback: callable) -> None:
+        """Register the plugin callback invoked from ``write_data``.
 
-        if details["type"] == "UINT16":
-            value = 1
-        elif details["type"] == "UINT32":
-            value = 56789
-        else:
-            value = 0
-
-        if details["scale"] != 1:
-            value *= details["scale"]
-
-        return value
+        The callback receives ``(register_name, value)`` exactly like the
+        Modbus helper so plugin code can use the same ``handle_cmd``
+        signature regardless of transport.
+        """
+        self.callback = callback
 
     async def write_data(self, register_name: str, value: Any) -> None:
-        """Write data to the device for a specific register."""
+        """Route a user-facing write through the registered callback.
+
+        JSON devices do not produce framed binary commands; the helper
+        simply hands the ``(register_name, value)`` pair to the owning
+        plugin, which composes and publishes the device-specific JSON
+        payload itself.
+        """
         if self.protocol_data is None:
             self.protocol_data = await self.load_protocol()
 
-        details = self.protocol_data["registers"].get(register_name)
-        if not details:
-            raise ValueError(f"Register {register_name} not found in protocol")
-        _LOGGER.debug("register_name: %s, value: %s", register_name, value)
+        _LOGGER.debug("JSON write_data: %s = %s", register_name, value)
 
-    def pack_data(self, slave_id: int, address: int, value: int) -> bytes:
-        """Pack data according to the protocol."""
-        write_command = self.protocol_data["write_command"]
-        packed_data = (
-            struct.pack(">B", slave_id)
-            + struct.pack(">B", write_command)
-            + struct.pack(">H", address)
-            + struct.pack(">H", value)
-        )
-        crc = self.crc16(packed_data)
-        packed_data += struct.pack(">H", crc)
-        return packed_data
+        if self.callback is not None:
+            await self.callback(register_name, value)
 
-    async def send_data(self, hass: HomeAssistant, url: str, data: bytes) -> bytes:
-        """Send data to the device and return the response."""
-        session = async_get_clientsession(hass)
-        async with session.post(url, data=data) as response:
-            return await response.read()
+    def parse_data(self, data: bytes | str) -> dict[str, Any]:
+        """Decode an inbound JSON payload into a dict.
+
+        Returns an empty dict on malformed input or when the payload is
+        not a JSON object. Errors are logged but never raised so one bad
+        message cannot crash a notify handler.
+        """
+        try:
+            decoded = json.loads(data)
+        except (TypeError, ValueError) as err:
+            _LOGGER.error("Invalid JSON payload: %s", err)
+            return {}
+
+        if not isinstance(decoded, dict):
+            _LOGGER.error("JSON payload is not an object: %r", decoded)
+            return {}
+
+        return decoded

--- a/custom_components/solar_manager/protocol_helper/protocol_helper.py
+++ b/custom_components/solar_manager/protocol_helper/protocol_helper.py
@@ -54,17 +54,31 @@ class ProtocolHelper(ABC):
         """Register a callback function to send data through mqtt."""
 
     @abstractmethod
-    async def read_data(self, register_name: str) -> Any:
-        """Read data from the device for a specific register."""
-
-    @abstractmethod
     async def write_data(self, register_name: str, value: Any) -> None:
         """Write data to the device for a specific register."""
 
-    @abstractmethod
-    def pack_data(self, slave_id: int, address: int, value: int) -> bytes:
-        """Pack data according to the protocol."""
+    async def read_data(self, register_name: str) -> Any:
+        """Read data from the device for a specific register.
 
-    @abstractmethod
+        Optional. Only protocols that poll the device from Home Assistant
+        need to implement this; push-based protocols (e.g. MQTT JSON)
+        can leave it unimplemented.
+        """
+        raise NotImplementedError
+
+    def pack_data(self, slave_id: int, address: int, value: int) -> bytes:
+        """Pack data according to the protocol.
+
+        Optional. Only protocols that emit framed binary commands
+        (e.g. Modbus) need to implement this.
+        """
+        raise NotImplementedError
+
     async def send_data(self, hass: HomeAssistant, url: str, data: bytes) -> bytes:
-        """Send data to the device and return the response."""
+        """Send data to the device and return the response.
+
+        Optional. Only transport-aware protocols need to implement this;
+        MQTT-based protocols publish via the integration's MQTT manager
+        rather than through the helper.
+        """
+        raise NotImplementedError

--- a/custom_components/solar_manager/switch.py
+++ b/custom_components/solar_manager/switch.py
@@ -168,3 +168,10 @@ async def async_setup_entry(
             )
         switches.append(switch)
     async_add_entities(switches)
+
+    # Expose the platform's add-entities callback to any device that opts
+    # in (e.g. ``SwitchesDevice``) so it can grow the entity set later
+    # when a new ``switch_count`` is reported on the ``online`` topic.
+    for device in hass.data[DOMAIN][serial].get("devices", []):
+        if hasattr(device, "set_add_entities_callback"):
+            device.set_add_entities_callback(async_add_entities)

--- a/custom_components/solar_manager/translations/en.json
+++ b/custom_components/solar_manager/translations/en.json
@@ -47,6 +47,54 @@
             "led": {
                 "name": "LED Indicator"
             },
+            "switch_01": {
+                "name": "Switch 1"
+            },
+            "switch_02": {
+                "name": "Switch 2"
+            },
+            "switch_03": {
+                "name": "Switch 3"
+            },
+            "switch_04": {
+                "name": "Switch 4"
+            },
+            "switch_05": {
+                "name": "Switch 5"
+            },
+            "switch_06": {
+                "name": "Switch 6"
+            },
+            "switch_07": {
+                "name": "Switch 7"
+            },
+            "switch_08": {
+                "name": "Switch 8"
+            },
+            "switch_09": {
+                "name": "Switch 9"
+            },
+            "switch_10": {
+                "name": "Switch 10"
+            },
+            "switch_11": {
+                "name": "Switch 11"
+            },
+            "switch_12": {
+                "name": "Switch 12"
+            },
+            "switch_13": {
+                "name": "Switch 13"
+            },
+            "switch_14": {
+                "name": "Switch 14"
+            },
+            "switch_15": {
+                "name": "Switch 15"
+            },
+            "switch_16": {
+                "name": "Switch 16"
+            },
             "anti_backflow_mode": {
                 "name": "Grid-Tied Anti-Backflow Status [d16]"
             },

--- a/custom_components/solar_manager/translations/zh-Hans.json
+++ b/custom_components/solar_manager/translations/zh-Hans.json
@@ -47,6 +47,54 @@
             "led": {
                 "name": "LED 指示灯"
             },
+            "switch_01": {
+                "name": "开关 1"
+            },
+            "switch_02": {
+                "name": "开关 2"
+            },
+            "switch_03": {
+                "name": "开关 3"
+            },
+            "switch_04": {
+                "name": "开关 4"
+            },
+            "switch_05": {
+                "name": "开关 5"
+            },
+            "switch_06": {
+                "name": "开关 6"
+            },
+            "switch_07": {
+                "name": "开关 7"
+            },
+            "switch_08": {
+                "name": "开关 8"
+            },
+            "switch_09": {
+                "name": "开关 9"
+            },
+            "switch_10": {
+                "name": "开关 10"
+            },
+            "switch_11": {
+                "name": "开关 11"
+            },
+            "switch_12": {
+                "name": "开关 12"
+            },
+            "switch_13": {
+                "name": "开关 13"
+            },
+            "switch_14": {
+                "name": "开关 14"
+            },
+            "switch_15": {
+                "name": "开关 15"
+            },
+            "switch_16": {
+                "name": "开关 16"
+            },
             "anti_backflow_mode": {
                 "name": "并网防逆流状态 [d16]"
             },


### PR DESCRIPTION
- New SwitchesDevice plugin with -K suffix detection for attached vs standalone
- Conditional network diagnostics and maintenance buttons based on serial suffix
- Dynamic switch count via MQTT online payload (min 2, grow/shrink reconciliation)
- JSON-over-MQTT command/notify using {switch_NN: on/off} format
- Refactored JsonProtocolHelper to be a generic JSON helper (no Modbus artifacts)
- Made ProtocolHelper base class methods optional for non-Modbus protocols
- switch.py wires async_add_entities callback for dynamic entity growth
- Translations for switch_01..switch_16 in en.json, zh-Hans.json, strings.json
- Registered Switches model in device_config.py

## Change Description
Briefly describe the changes and purpose of this PR.

## Related Issues
List any related Issues (e.g., #123).

## Influence device

- [ ] MakeSkyBlue
- [ ] MakeSkyBlue Mppt

## Testing
Describe how you tested these changes:

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed
- [ ] Documentation updated (if needed)
- [x] No new warnings or errors
- [ ] Local tests passed
